### PR TITLE
Reduce log size

### DIFF
--- a/fetcher.py
+++ b/fetcher.py
@@ -19,8 +19,8 @@ with open("SECRETS.txt") as f:
 
 SLEEP_TIME = 1
 
-OFFLINE_STATUS_JSON = """{"lat": "offline", "webStatus": "invisible", "fbAppStatus": "invisible", "otherStatus": "invisible", "status": "invisible", "messengerStatus": "invisible"}"""
-ACTIVE_STATUS_JSON = """{ "lat": "online", "webStatus": "invisible", "fbAppStatus": "invisible", "otherStatus": "invisible", "status": "active", "messengerStatus": "invisible"}"""
+OFFLINE_STATUS_JSON = "0"
+ACTIVE_STATUS_JSON = "1"
 
 class Fetcher():
     # Headers to send with every request.

--- a/history.py
+++ b/history.py
@@ -4,6 +4,8 @@ import time
 
 import status
 
+OFFLINE_STATUS_JSON = """{"lat": "offline", "webStatus": "invisible", "fbAppStatus": "invisible", "otherStatus": "invisible", "status": "invisible", "messengerStatus": "invisible"}"""
+ACTIVE_STATUS_JSON = """{ "lat": "online", "webStatus": "invisible", "fbAppStatus": "invisible", "otherStatus": "invisible", "status": "active", "messengerStatus": "invisible"}"""
 
 class StatusHistory():
     """Object representing the history for a particular user. History stored sparse."""
@@ -35,6 +37,10 @@ class StatusHistory():
             time, fields = line.split("|")
             # Only add new times, preferring earlier records in the file. This is probably not optimal since later records seem to be more likely to be LATs, but oh well gotta break a few algorithmic contraints to make a BILLION dollars.
             if time not in seen_times:
+                if fields is "0":
+                    fields = OFFLINE_STATUS_JSON
+                elif fields is "1":
+                    fields = ACTIVE_STATUS_JSON 
                 seen_times.add(time)
                 status_obj = status.Status(int(float(time)), fields)
                 activity.append(status_obj)


### PR DESCRIPTION
As offline/active status for LAT are fix. They can be replaced by shorter string.

Use this command to replace old logs:

```
for i in *.txt; do
  sed -i 's/{"lat": "offline", "webStatus": "invisible", "fbAppStatus": "invisible", "otherStatus": "invisible", "status": "invisible", "messengerStatus": "invisible"}/0/g' $i
  sed -i 's/{ "lat": "online", "webStatus": "invisible", "fbAppStatus": "invisible", "otherStatus": "invisible", "status": "active", "messengerStatus": "invisible"}/1/g' $i
done
```
